### PR TITLE
Documentation Fix: Fixed Typo in code snippet

### DIFF
--- a/developerguide/px4-example-code/hg-px4-example-lab-3.md
+++ b/developerguide/px4-example-code/hg-px4-example-lab-3.md
@@ -32,7 +32,7 @@ px4_add_module(
 	MAIN hg_led
 	STACK_MAIN 2000
 	SRCS
-		hg_gyro.c
+		hg_led.c
 	DEPENDS
 	)
 ```


### PR DESCRIPTION
The example code for "CMakeLists.txt" in Lab 3 of the example code has a typo. Instead of hg_gyro.c, it should be hg_led.c we are building the led application from lab 2 and not the gyro application from lab 1, as mentioned above the code snippet. 