### PR TITLE
Documentation Fix: Fixed a Typo in Code Snippet

### DIFF
--- a/developerguide/px4-example-code/hg-px4-example-lab-3.md
+++ b/developerguide/px4-example-code/hg-px4-example-lab-3.md
@@ -32,7 +32,7 @@ px4_add_module(
 	MAIN hg_led
 	STACK_MAIN 2000
 	SRCS
-		hg_gyro.c
+		hg_led.c
 	DEPENDS
 	)
 ```


### PR DESCRIPTION
In the third PX4 example lab, the "CMakeLists.txt" code snippet has a typo. Instead of "hg_gyro.c" it should be "hg_led.c" because the example mentions above the code snippet that we are building the led application from lab 2 and not the gyro application from lab 1. 