### PR TITLE
assembly: make comments on screws for motor mount more generic

### DIFF
--- a/userguide/assembly/preparing-the-arms-and-motors.md
+++ b/userguide/assembly/preparing-the-arms-and-motors.md
@@ -15,7 +15,7 @@ See also our notes under Safety section for additional general precautions.&#x20
 
 ## Motor mounts
 
-The four motor mounts go on the end of the arms (carbon fiber tubes). Each one consists of two small carbon fiber plates, four tube clamps (the arch-shaped parts), and four long M2.5 screws with locknuts (with an elastic ring inside). Additionally, you need the motor itself and four short M3 screws from the labeled bag.
+The four motor mounts go on the end of the arms (carbon fiber tubes). Each one consists of two small carbon fiber plates, four tube clamps (the arch-shaped parts), and four long M2.5 screws with locknuts (with an elastic ring inside). Additionally, you need the motor itself and four short M3x5 screws from a separate bag.
 
 {% hint style="warning" %}
 When watching the video below, please use the updated instructions below to attach each motor.
@@ -52,7 +52,7 @@ Use the video below to get an idea of how to attach the motor. It takes 4 screws
 {% embed url="https://www.youtube.com/watch?v=7p2URKC9QZg" %}
 
 {% hint style="danger" %}
-For the motors, make sure that you are using the +/- 5 mm long **silver M3 screws from the separate package with the label** saying to use these screws for mounting the motors.\
+For the motors, make sure that you are using the **+/- 5 mm long M3 screws from a separate package**.\
 \
 **Do not use the longer M3 screws included with the frame**, these screws may go in too deep and can damage the motor windings. The **black screws** included with the motors **might be safe to use**, but be careful.
 {% endhint %}
@@ -70,7 +70,7 @@ While we have not seen many problems in practice, you may still want to consider
 Note that the main body screws for the arm clamps have nylon locking nuts and are not really affected as much by the vibrations.
 {% endhint %}
 
-![Motor installed onto the carbon fiber plate. You should use the M3 screws from the labeled bag.](../../.gitbook/assets/assets\_-l9gltb-tz\_xakbqu-al\_-lyzuzz7xrf0gmu8v\_mh\_-lyzy8uicdfhhcqaoeg1\_20181120\_165950.jpg)
+![Motor installed onto the carbon fiber plate. You should use the M3x5 screws from a separate bag.](../../.gitbook/assets/assets\_-l9gltb-tz\_xakbqu-al\_-lyzuzz7xrf0gmu8v\_mh\_-lyzy8uicdfhhcqaoeg1\_20181120\_165950.jpg)
 
 For the next step, we need: four tube clamps, the other carbon plate, four long M2.5 screws and the locknuts.&#x20;
 


### PR DESCRIPTION
The motor parts from the drone kit I got differs slightly from the manual. My kit doesn't have a separate bag with silver screws with the label saying to use these screws for mounting the motors.

Instead the bag is unlabeled and contains black m3x5 screws.

So when updating the doc to be more generic then it is correct for both older and newer kits and takes away some confusion